### PR TITLE
max_potency_ratio

### DIFF
--- a/filter.json
+++ b/filter.json
@@ -1,0 +1,11 @@
+{
+    "skip_business": true,
+    "skip_non_business": false,
+    "min_followers": 30,
+    "max_followers": 1000,
+    "min_followings": 30,
+    "max_followings": 1000,
+    "min_potency_ratio": 0.4,
+    "max_potency_ratio": 1,
+    "follow_private_or_empty": true
+}

--- a/src/filter.py
+++ b/src/filter.py
@@ -11,6 +11,7 @@ FIELD_MAX_FOLLOWERS = "max_followers"
 FIELD_MIN_FOLLOWINGS = "min_followings"
 FIELD_MAX_FOLLOWINGS = "max_followings"
 FIELD_MIN_POTENCY_RATIO = "min_potency_ratio"
+FIELD_MAX_POTENCY_RATIO = "max_potency_ratio"
 FIELD_FOLLOW_PRIVATE_OR_EMPTY = "follow_private_or_empty"
 
 
@@ -36,6 +37,7 @@ class Filter:
         field_min_followings = self.conditions.get(FIELD_MIN_FOLLOWINGS)
         field_max_followings = self.conditions.get(FIELD_MAX_FOLLOWINGS)
         field_min_potency_ratio = self.conditions.get(FIELD_MIN_POTENCY_RATIO)
+        field_max_potency_ratio = self.conditions.get(FIELD_MAX_POTENCY_RATIO)
 
         if field_skip_business is not None or field_skip_non_business is not None:
             has_business_category = self._has_business_category(device)
@@ -114,16 +116,25 @@ class Filter:
                     + COLOR_ENDC
                 )
                 return False
-            if field_min_potency_ratio is not None and (
-                int(followings) == 0
-                or followers / followings < float(field_min_potency_ratio)
+            if (
+                field_min_potency_ratio is not None
+                and field_max_potency_ratio is not None
+                and (
+                    int(followings) == 0
+                    or (
+                        followers / followings < float(field_min_potency_ratio)
+                        or followers / followings > field_max_potency_ratio
+                    )
+                )
             ):
                 print(
                     COLOR_OKGREEN
                     + "@"
                     + username
-                    + "'s potency ratio is less than "
+                    + "'s potency ratio is not between "
                     + str(field_min_potency_ratio)
+                    + " and "
+                    + str(field_max_potency_ratio)
                     + ", skip."
                     + COLOR_ENDC
                 )


### PR DESCRIPTION
I think that is a good way to reach people you
really want to follow.

In previous version, it would follow if user's ratio
les than min_previous_ratio. I.E. Follow = 100, Following = 10000
its ratio will be 0.01. I think following that user is not a good idea.

So basically, we will be able to control the scale that we really want.
It works properly for me.

If you accept this change, there should be a field in filter.json
"max_potency_ratio":

{
"skip_business": true,
"skip_non_business": false,
"min_followers": 30,
"max_followers": 1000,
"min_followings": 30,
"max_followings": 1000,
"min_potency_ratio": 0.3,
"max_potency_ratio": 1,
"follow_private_or_empty": true
}

this is my settings, by looking that, it wont follow a user which has
300 follower, 1000 followings -> ratio 0.3