### PR TITLE
random double-click improvement

### DIFF
--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -1,6 +1,7 @@
 import logging
 from enum import Enum, unique
 from random import uniform
+from time import sleep
 
 import uiautomator2
 
@@ -181,16 +182,13 @@ class DeviceFacade:
                 raise DeviceFacade.JsonRpcError(e)
 
         def _double_click_v2(self):
-
-            visible_bounds = self.get_bounds()
-            horizontal_offset = visible_bounds["left"]
-            horizontal_diff = visible_bounds["right"] - visible_bounds["left"]
-            vertical_offset = visible_bounds["top"]
-            vertical_diff = visible_bounds["bottom"] - visible_bounds["top"]
-            center_x = horizontal_offset + ((horizontal_diff) / 2)
-            center_y = vertical_offset + ((vertical_diff) / 2)
+            offset_x = uniform(0.15, 0.85)
+            offset_y = uniform(0.15, 0.85)
+            sleep_between_clicks = uniform(0.0, 0.2)
             try:
-                self.deviceV2.double_click(center_x, center_y, duration=0)
+                self.viewV2.click(offset=(offset_x, offset_y))
+                sleep(sleep_between_clicks)
+                self.viewV2.click(offset=(offset_x, offset_y))
             except uiautomator2.JSONRPCError as e:
                 raise DeviceFacade.JsonRpcError(e)
 


### PR DESCRIPTION
just an easy improvement..
I've realized that the double click was on the middle screen, no matter what! it looks like that this method doesn't have the offset parameter because it is not related to the UI object!! so I decided to change the logic and made two single clicks with a random delay.. :)

Other info:
You can only pass x, y and time between the clicks in double_click().
If you don't you get an error: "double_click() missing 2 required positional arguments: 'x' and 'y'"

Recap:
With double_click(x,y) you can do a double click on the screen in a coordinate you pass as argument.
With click() it press on the UI object center, with offset I'm able to press in all the right area without problems.

That's the reason I think we should use two click(offset=..) instead of a double_click(x+offset, y+offset) which in original code was a double_click on the middle of the screen.