### PR TITLE
Fix crash report 0008

### DIFF
--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -175,13 +175,27 @@ class DeviceFacade:
             except uiautomator2.JSONRPCError as e:
                 raise DeviceFacade.JsonRpcError(e)
 
-        def double_click(self):
+        def double_click(self, padding=0.3):
+            """Double click randomly in the selected view using padding
+            padding: % of how far from the borders we want the double
+                    click to happen.
+            """
             visible_bounds = self.get_bounds()
+            horizontal_len = visible_bounds["right"] - visible_bounds["left"]
+            vertical_len = visible_bounds["bottom"] - visible_bounds["top"]
+            horizintal_padding = int(padding * horizontal_len)
+            vertical_padding = int(padding * vertical_len)
             random_x = int(
-                uniform(visible_bounds["left"] + 1, visible_bounds["right"] - 1)
+                uniform(
+                    visible_bounds["left"] + horizintal_padding,
+                    visible_bounds["right"] - horizintal_padding,
+                )
             )
             random_y = int(
-                uniform(visible_bounds["top"] + 1, visible_bounds["bottom"] - 1)
+                uniform(
+                    visible_bounds["top"] + vertical_padding,
+                    visible_bounds["bottom"] - vertical_padding,
+                )
             )
             try:
                 logger.debug(f"Double click in x={random_x}; y={random_y}")

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -398,18 +398,19 @@ class OpenedPostView:
             resourceIdMatches=case_insensitive_re(OpenedPostView.BTN_LIKE_RES_ID)
         )
 
-        # threshold of 30% of the display height
-        threshold = int((0.3) * self.device.get_info()["displayHeight"])
-        like_btn_top_bound = like_btn_view.get_bounds()["top"]
-        is_like_btn_in_the_bottom = like_btn_top_bound > threshold
-        if not is_like_btn_in_the_bottom:
-            logger.debug(
-                f"Like button is to high ({like_btn_top_bound} px). Threshold is {threshold} px"
-            )
-        if not like_btn_view.exists():
+        if like_btn_view.exists():
+            # threshold of 30% of the display height
+            threshold = int((0.3) * self.device.get_info()["displayHeight"])
+            like_btn_top_bound = like_btn_view.get_bounds()["top"]
+            is_like_btn_in_the_bottom = like_btn_top_bound > threshold
+            if not is_like_btn_in_the_bottom:
+                logger.debug(
+                    f"Like button is to high ({like_btn_top_bound} px). Threshold is {threshold} px"
+                )
+        else:
             logger.debug("Like button not found bellow the post.")
 
-        if not is_like_btn_in_the_bottom or not like_btn_view.exists():
+        if not like_btn_view.exists() or not is_like_btn_in_the_bottom:
             if scroll_to_find:
                 logger.debug("Try to scroll tiny bit down...")
                 # Remember: to scroll down we need to swipe up :)
@@ -420,7 +421,7 @@ class OpenedPostView:
                     )
                 )
 
-            if not scroll_to_find or scroll_to_find and not like_btn_view.exists():
+            if not scroll_to_find or not like_btn_view.exists():
                 logger.error("Could not find like button bellow the post")
                 return None
 


### PR DESCRIPTION
- [bug] Only access like button if it exists
   Check if the like button exists first
   before trying to get its bounds
- [improvement] Avoid double clicking close to the borders
   Some posts have Reels link or tagged users link
   in the bottom left corner. Now the double click
   randomly click in an area inside of the selected
   element but with a 30% padding from all sides
   to avoid clicking in undesired objects.