### PR TITLE
filter added - follow_only_private

### DIFF
--- a/GramAddict/core/filter.py
+++ b/GramAddict/core/filter.py
@@ -160,6 +160,6 @@ class Filter:
         try:
             private = profileView.isPrivateAccount()
         except Exception:
-            logger.error(f"Cannot find whether it is private or not")
+            logger.error("Cannot find whether it is private or not")
 
         return private

--- a/GramAddict/core/filter.py
+++ b/GramAddict/core/filter.py
@@ -16,6 +16,7 @@ FIELD_MIN_FOLLOWINGS = "min_followings"
 FIELD_MAX_FOLLOWINGS = "max_followings"
 FIELD_MIN_POTENCY_RATIO = "min_potency_ratio"
 FIELD_FOLLOW_PRIVATE_OR_EMPTY = "follow_private_or_empty"
+FIELD_FOLLOW_ONLY_PRIVATE = "follow_only_private"
 
 
 class Filter:
@@ -40,6 +41,19 @@ class Filter:
         field_min_followings = self.conditions.get(FIELD_MIN_FOLLOWINGS)
         field_max_followings = self.conditions.get(FIELD_MAX_FOLLOWINGS)
         field_min_potency_ratio = self.conditions.get(FIELD_MIN_POTENCY_RATIO)
+
+        field_follow_only_private = self.conditions.get(FIELD_FOLLOW_ONLY_PRIVATE)
+
+        if field_follow_only_private is not None:
+            is_private = self._is_private_account(device)
+
+            if field_follow_only_private and is_private is False:
+
+                logger.info(
+                    f"@{username} has public account, skip.",
+                    extra={"color": f"{Fore.GREEN}"},
+                )
+                return False
 
         if field_skip_business is not None or field_skip_non_business is not None:
             has_business_category = self._has_business_category(device)
@@ -138,3 +152,14 @@ class Filter:
             className="android.widget.TextView",
         )
         return business_category_view.exists()
+
+    @staticmethod
+    def _is_private_account(device):
+        private = False
+        profileView = ProfileView(device)
+        try:
+            private = profileView.isPrivateAccount()
+        except Exception:
+            logger.error(f"Cannot find whether it is private or not")
+
+        return private


### PR DESCRIPTION
In my strong opinion, people who has public account are less likely follow back.

If you turn on that filter, be careful, bot will not like any posts, it is only for following private accounts neither public acc nor business .

Personally i combine that filter with min and max potency ratio.


![image](https://user-images.githubusercontent.com/51965140/99404305-8600c880-28fc-11eb-95c0-b1290c0b3f69.png)
![image](https://user-images.githubusercontent.com/51965140/99404384-9d3fb600-28fc-11eb-9d70-53ebb40bef0d.png)
