### PR TITLE
Fix infinite loop while running unfollow

### DIFF
--- a/GramAddict/plugins/force_interact.dis
+++ b/GramAddict/plugins/force_interact.dis
@@ -196,22 +196,22 @@ class ForceIteract(Plugin):
         logger.info("Unfollow @" + username)
         attempts = 0
 
-        while True:
+        unfollow_button = None
+        attempts = 2
+        for _ in range(attempts)
             unfollow_button = device.find(
                 classNameMatches=ClassName.BUTTON,
                 clickable=True,
                 textMatches=FOLLOWING_REGEX,
             )
-            if not unfollow_button.exists() and attempts <= 1:
-                scrollable = device.find(
-                    classNameMatches=ClassName.VIEW_PAGER
-                )
-                scrollable.scroll(DeviceFacade.Direction.TOP)
-                attempts += 1
-            else:
+            if unfollow_button.exists():
                 break
+            scrollable = device.find(
+                classNameMatches=ClassName.VIEW_PAGER
+            )
+            scrollable.scroll(DeviceFacade.Direction.TOP)
 
-        if not unfollow_button.exists():
+        if not unfollow_button or not unfollow_button.exists():
             logger.error("Cannot find Following button.")
             save_crash(device)
 


### PR DESCRIPTION
# Fix infinite loop while running unfollow

While running unfollow the bot sometimes got in an infinite loop. The only wait to get rid of it was to manually
type CTRL + C and resume.

Also got rid of unnecessary `while True` loops that could cause the same problem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran unfollow script

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have tested my code in every way I can think of to prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules