### PR TITLE
🎁 More data in interacted_users.json - Add history_filters_users.json - Issue #139 - v1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.idea
 /.vscode
 */*.yml
+history_filters_users.*
 interacted_users.*
 sessions.json
 *.pyc

--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -135,7 +135,7 @@ class DeviceFacade:
         )
         data = status.read()
         flag = search("mDreamingLockscreen=(true|false)", data)
-        return True if flag.group(1) == "true" else False
+        return True if flag is not None and flag.group(1) == "true" else False
 
     def is_alive(self):
         # v2 only - for atx_agent

--- a/GramAddict/core/filter.py
+++ b/GramAddict/core/filter.py
@@ -63,7 +63,15 @@ class SkipReason(Enum):
 
 
 class Profile(object):
-    def __init__(self, follow_button_text, is_private, has_business_category, posts_count, biography, fullname):
+    def __init__(
+        self,
+        follow_button_text,
+        is_private,
+        has_business_category,
+        posts_count,
+        biography,
+        fullname,
+    ):
         self.datetime = str(datetime.now())
         self.followers = 0
         self.followings = 0
@@ -78,7 +86,10 @@ class Profile(object):
     def set_followers_and_following(self, followers, followings):
         self.followers = followers
         self.followings = followings
-        self.potency_ratio = 0 if self.followings == 0 else self.followers / self.followings
+        self.potency_ratio = (
+            0 if self.followings == 0 else self.followers / self.followings
+        )
+
 
 class Filter:
     conditions = None
@@ -147,7 +158,9 @@ class Filter:
                         f"You follow @{username}, skip.",
                         extra={"color": f"{Fore.GREEN}"},
                     )
-                    return self.return_check_profile(username, profile_data, SkipReason.YOU_FOLLOW)
+                    return self.return_check_profile(
+                        username, profile_data, SkipReason.YOU_FOLLOW
+                    )
 
             if field_skip_follower:
                 if profile_data.follow_button_text == FollowStatus.FOLLOW_BACK:
@@ -155,7 +168,9 @@ class Filter:
                         f"@{username} follows you, skip.",
                         extra={"color": f"{Fore.GREEN}"},
                     )
-                    return self.return_check_profile(username, profile_data, SkipReason.FOLLOW_YOU)
+                    return self.return_check_profile(
+                        username, profile_data, SkipReason.FOLLOW_YOU
+                    )
 
         if field_interact_only_private:
             logger.debug("Checking if account is private...")
@@ -166,14 +181,18 @@ class Filter:
                     f"@{username} has public account, skip.",
                     extra={"color": f"{Fore.GREEN}"},
                 )
-                return self.return_check_profile(username, profile_data, SkipReason.IS_PRIVATE)
+                return self.return_check_profile(
+                    username, profile_data, SkipReason.IS_PRIVATE
+                )
 
             elif field_interact_only_private and profile_data.is_private is None:
                 logger.info(
                     f"Could not determine if @{username} is public or private, skip.",
                     extra={"color": f"{Fore.GREEN}"},
                 )
-                return self.return_check_profile(username, profile_data, SkipReason.UNKNOWN_PRIVACY)
+                return self.return_check_profile(
+                    username, profile_data, SkipReason.UNKNOWN_PRIVACY
+                )
 
         if (
             field_min_followers is not None
@@ -186,7 +205,10 @@ class Filter:
             logger.debug(
                 "Checking if account is within follower/following parameters..."
             )
-            if profile_data.followers is not None and profile_data.followings is not None:
+            if (
+                profile_data.followers is not None
+                and profile_data.followings is not None
+            ):
                 if field_min_followers is not None and profile_data.followers < int(
                     field_min_followers
                 ):
@@ -194,7 +216,9 @@ class Filter:
                         f"@{username} has less than {field_min_followers} followers, skip.",
                         extra={"color": f"{Fore.GREEN}"},
                     )
-                    return self.return_check_profile(username, profile_data, SkipReason.LT_FOLLOWERS)
+                    return self.return_check_profile(
+                        username, profile_data, SkipReason.LT_FOLLOWERS
+                    )
                 if field_max_followers is not None and profile_data.followers > int(
                     field_max_followers
                 ):
@@ -202,7 +226,9 @@ class Filter:
                         f"@{username} has has more than {field_max_followers} followers, skip.",
                         extra={"color": f"{Fore.GREEN}"},
                     )
-                    return self.return_check_profile(username, profile_data, SkipReason.GT_FOLLOWERS)
+                    return self.return_check_profile(
+                        username, profile_data, SkipReason.GT_FOLLOWERS
+                    )
                 if field_min_followings is not None and profile_data.followings < int(
                     field_min_followings
                 ):
@@ -210,7 +236,9 @@ class Filter:
                         f"@{username} has less than {field_min_followings} followings, skip.",
                         extra={"color": f"{Fore.GREEN}"},
                     )
-                    return self.return_check_profile(username, profile_data, SkipReason.LT_FOLLOWINGS)
+                    return self.return_check_profile(
+                        username, profile_data, SkipReason.LT_FOLLOWINGS
+                    )
                 if field_max_followings is not None and profile_data.followings > int(
                     field_max_followings
                 ):
@@ -218,25 +246,33 @@ class Filter:
                         f"@{username} has more than {field_max_followings} followings, skip.",
                         extra={"color": f"{Fore.GREEN}"},
                     )
-                    return self.return_check_profile(username, profile_data, SkipReason.GT_FOLLOWINGS)
+                    return self.return_check_profile(
+                        username, profile_data, SkipReason.GT_FOLLOWINGS
+                    )
 
                 if field_min_potency_ratio != 0 or field_max_potency_ratio != 999:
                     if (
                         int(profile_data.followings) == 0
-                        or profile_data.followers / profile_data.followings < float(field_min_potency_ratio)
-                        or profile_data.followers / profile_data.followings > float(field_max_potency_ratio)
+                        or profile_data.followers / profile_data.followings
+                        < float(field_min_potency_ratio)
+                        or profile_data.followers / profile_data.followings
+                        > float(field_max_potency_ratio)
                     ):
                         logger.info(
                             f"@{username}'s potency ratio is not between {field_min_potency_ratio} and {field_max_potency_ratio}, skip.",
                             extra={"color": f"{Fore.GREEN}"},
                         )
-                        return self.return_check_profile(username, profile_data, SkipReason.POTENCY_RATIO)
+                        return self.return_check_profile(
+                            username, profile_data, SkipReason.POTENCY_RATIO
+                        )
 
             else:
                 logger.critical(
                     "Either followers, followings, or possibly both are undefined. Cannot filter."
                 )
-                return self.return_check_profile(username, profile_data, SkipReason.UNDEFINED_FOLLOWERS_FOLLOWING)
+                return self.return_check_profile(
+                    username, profile_data, SkipReason.UNDEFINED_FOLLOWERS_FOLLOWING
+                )
 
         if field_skip_business or field_skip_non_business:
             logger.debug("Checking if account is a business...")
@@ -245,13 +281,17 @@ class Filter:
                     f"@{username} has business account, skip.",
                     extra={"color": f"{Fore.GREEN}"},
                 )
-                return self.return_check_profile(username, profile_data, SkipReason.HAS_BUSINESS)
+                return self.return_check_profile(
+                    username, profile_data, SkipReason.HAS_BUSINESS
+                )
             if field_skip_non_business and profile_data.has_business_category is False:
                 logger.info(
                     f"@{username} has non business account, skip.",
                     extra={"color": f"{Fore.GREEN}"},
                 )
-                return self.return_check_profile(username, profile_data, SkipReason.HAS_NON_BUSINESS)
+                return self.return_check_profile(
+                    username, profile_data, SkipReason.HAS_NON_BUSINESS
+                )
 
         if field_min_posts is not None:
             if field_min_posts > profile_data.posts_count:
@@ -259,7 +299,9 @@ class Filter:
                     f"@{username} doesn't have enough posts ({profile_data.posts_count}), skip.",
                     extra={"color": f"{Fore.GREEN}"},
                 )
-                return self.return_check_profile(username, profile_data, SkipReason.NOT_ENOUGH_POSTS)
+                return self.return_check_profile(
+                    username, profile_data, SkipReason.NOT_ENOUGH_POSTS
+                )
 
         if (
             len(field_blacklist_words) > 0
@@ -281,7 +323,9 @@ class Filter:
                             f"@{username} found a blacklisted word '{w}' in biography, skip.",
                             extra={"color": f"{Fore.GREEN}"},
                         )
-                        return self.return_check_profile(username, profile_data, SkipReason.BLACKLISTED_WORD)
+                        return self.return_check_profile(
+                            username, profile_data, SkipReason.BLACKLISTED_WORD
+                        )
 
             if len(field_mandatory_words) > 0:
                 logger.debug("Checking if account has mandatory words in biography...")
@@ -298,7 +342,9 @@ class Filter:
                         f"@{username} mandatory words not found in biography, skip.",
                         extra={"color": f"{Fore.GREEN}"},
                     )
-                    return self.return_check_profile(username, profile_data, SkipReason.MISSING_MANDATORY_WORDS)
+                    return self.return_check_profile(
+                        username, profile_data, SkipReason.MISSING_MANDATORY_WORDS
+                    )
 
             if field_specific_alphabet is not None:
                 if profile_data.biography != "":
@@ -313,7 +359,9 @@ class Filter:
                             f"@{username}'s biography alphabet is not {field_specific_alphabet}. ({alphabet}), skip.",
                             extra={"color": f"{Fore.GREEN}"},
                         )
-                        return self.return_check_profile(username, profile_data, SkipReason.ALPHABET_NOT_MATCH)
+                        return self.return_check_profile(
+                            username, profile_data, SkipReason.ALPHABET_NOT_MATCH
+                        )
                 else:
                     logger.debug("Checking primary character set of name...")
                     if profile_data.fullname != "":
@@ -325,7 +373,11 @@ class Filter:
                                 f"@{username}'s name alphabet is not {field_specific_alphabet}. ({alphabet}), skip.",
                                 extra={"color": f"{Fore.GREEN}"},
                             )
-                            return self.return_check_profile(username, profile_data, SkipReason.ALPHABET_NAME_NOT_MATCH)
+                            return self.return_check_profile(
+                                username,
+                                profile_data,
+                                SkipReason.ALPHABET_NAME_NOT_MATCH,
+                            )
 
         # If no filters return false, we are good to proceed
         return self.return_check_profile(username, profile_data, None)
@@ -349,7 +401,7 @@ class Filter:
             has_business_category=self._has_business_category(device, profileView),
             posts_count=self._get_posts_count(device, profileView),
             biography=self._get_profile_biography(device, profileView),
-            fullname=self._get_fullname(device, profileView)
+            fullname=self._get_fullname(device, profileView),
         )
         followers, following = self._get_followers_and_followings(device)
         profile.set_followers_and_following(followers, following)

--- a/GramAddict/core/filter.py
+++ b/GramAddict/core/filter.py
@@ -305,7 +305,7 @@ class Filter:
                     logger.debug(
                         "Checking primary character set of account biography..."
                     )
-                    biography = biography.replace("\n", "")
+                    biography = profile_data.biography.replace("\n", "")
                     alphabet = self._find_alphabet(biography, field_specific_alphabet)
 
                     if alphabet != field_specific_alphabet and alphabet != "":

--- a/GramAddict/core/interaction.py
+++ b/GramAddict/core/interaction.py
@@ -169,7 +169,7 @@ def interact_with_user(
                 device, username, follow_percentage, args, session_state, swipe_amount
             ),
             number_of_liked,
-            number_of_watched
+            number_of_watched,
         )
 
     return True, False, number_of_liked, number_of_watched

--- a/GramAddict/core/interaction.py
+++ b/GramAddict/core/interaction.py
@@ -47,18 +47,21 @@ def interact_with_user(
     args,
     session_state,
     current_mode,
-) -> Tuple[bool, bool]:
+) -> Tuple[bool, bool, int, int]:
     """
-    :return: (whether interaction succeed, whether @username was followed during the interaction)
+    :return: (whether interaction succeed, whether @username was followed during the interaction, number of liked, number of watched)
     """
+    number_of_liked = 0
+    number_of_watched = 0
+
     if username == my_username:
         logger.info("It's you, skip.")
-        return False, False
+        return False, False, number_of_liked, number_of_watched
 
     random_sleep()
 
     if not profile_filter.check_profile(device, username):
-        return False, False
+        return False, False, number_of_liked, number_of_watched
 
     likes_value = get_value(likes_count, "Likes count: {}", 2)
     if likes_value > 12:
@@ -77,12 +80,12 @@ def interact_with_user(
             followed = _follow(
                 device, username, follow_percentage, args, session_state, 0
             )
-            return True, followed
+            return True, followed, number_of_liked, number_of_watched
         else:
             logger.info("Skip user.", extra={"color": f"{Fore.GREEN}"})
-            return False, False
+            return False, False, number_of_liked, number_of_watched
 
-    _watch_stories(
+    number_of_watched = _watch_stories(
         device,
         profile_view,
         username,
@@ -95,7 +98,7 @@ def interact_with_user(
 
     swipe_amount = ProfileView(device).swipe_to_fit_posts()
     if swipe_amount == -1:
-        return False, False
+        return False, False, number_of_liked, number_of_watched
     random_sleep()
 
     likes_value = get_value(likes_count, "Likes count: {}", 2)
@@ -131,19 +134,9 @@ def interact_with_user(
 
         like_succeed = False
         if opened_post_view:
-            logger.info("Double click post.")
-
-            like_succeed = opened_post_view.likePost()
-            if not like_succeed:
-                logger.debug("Double click failed. Try the like button.")
-                like_succeed = opened_post_view.likePost(click_btn_like=True)
-
-            if like_succeed:
-                logger.debug("Like succeed. Check for block.")
-                detect_block(device)
-                on_like()
-            else:
-                logger.warning("Fail to like post. Let's continue...")
+            like_succeed = do_like(opened_post_view, device, on_like)
+            if like_succeed is True:
+                number_of_liked += 1
 
             logger.info("Back to profile.")
             device.back()
@@ -166,7 +159,7 @@ def interact_with_user(
 
             if not followed:
                 logger.info("Skip user.", extra={"color": f"{Fore.GREEN}"})
-            return False, followed
+            return False, followed, number_of_liked, number_of_watched
 
         random_sleep()
     if can_follow:
@@ -175,13 +168,15 @@ def interact_with_user(
             _follow(
                 device, username, follow_percentage, args, session_state, swipe_amount
             ),
+            number_of_liked,
+            number_of_watched
         )
 
-    return True, False
+    return True, False, number_of_liked, number_of_watched
 
 
 def do_like(opened_post_view, device, on_like):
-    logger.info("Double click post")
+    logger.info("Double click post.")
 
     like_succeed = opened_post_view.likePost()
     if not like_succeed:
@@ -189,7 +184,7 @@ def do_like(opened_post_view, device, on_like):
         like_succeed = opened_post_view.likePost(click_btn_like=True)
 
     if like_succeed:
-        logger.info("Like succeeded!")
+        logger.debug("Like succeed. Check for block.")
         detect_block(device)
         on_like()
     else:
@@ -330,7 +325,7 @@ def _watch_stories(
     ):
         story_chance = randint(1, 100)
         if story_chance > stories_percentage:
-            return False
+            return 0
 
         stories_to_watch = get_value(stories_to_watch, "Stories count: {}", 0)
 
@@ -339,15 +334,17 @@ def _watch_stories(
             stories_to_watch = 6
 
         if stories_to_watch == 0:
-            return False
+            return 0
 
         if profile_view.isStoryAvailable():
             profile_picture = profile_view.profileImage()
+            stories_counter = 0
             if profile_picture.exists():
                 logger.debug("Open the first story")
                 profile_picture.click()
                 random_sleep(1, 2)
                 on_watch()
+                stories_counter += 1
                 random_sleep()
 
                 if stories_to_watch > 1:
@@ -362,6 +359,7 @@ def _watch_stories(
                                 ):
                                     story_frame.click(story_view.Location.RIGHT)
                                     on_watch()
+                                    stories_counter += 1
                                     random_sleep()
                             except Exception:
                                 break
@@ -377,8 +375,8 @@ def _watch_stories(
                         random_sleep()
                     else:
                         break
-                return True
-        return False
+                return stories_counter
+        return 0
     else:
         logger.info("Reached total watch limit, not watching stories.")
-        return False
+        return 0

--- a/GramAddict/core/storage.py
+++ b/GramAddict/core/storage.py
@@ -40,7 +40,9 @@ class Storage:
             with open(self.interacted_users_path) as json_file:
                 self.interacted_users = json.load(json_file)
 
-        self.history_filter_users_path = my_username + "/" + FILENAME_HISTORY_FILTER_USERS
+        self.history_filter_users_path = (
+            my_username + "/" + FILENAME_HISTORY_FILTER_USERS
+        )
         if os.path.exists(self.history_filter_users_path):
             with open(self.history_filter_users_path) as json_file:
                 self.history_filter_users = json.load(json_file)
@@ -75,12 +77,7 @@ class Storage:
         else:
             return FollowingStatus[user[USER_FOLLOWING_STATUS].upper()]
 
-    def add_filter_user(
-        self,
-        username,
-        profile_data,
-        skip_reason=None
-    ):
+    def add_filter_user(self, username, profile_data, skip_reason=None):
         # user = self.history_filter_users.get(username, {})
         user = profile_data.__dict__
         user["follow_button_text"] = profile_data.follow_button_text.name

--- a/GramAddict/core/storage.py
+++ b/GramAddict/core/storage.py
@@ -62,7 +62,17 @@ class Storage:
         else:
             return FollowingStatus[user[USER_FOLLOWING_STATUS].upper()]
 
-    def add_interacted_user(self, username, followed=False, unfollowed=False):
+    def add_interacted_user(
+            self,
+            username,
+            session_id,
+            liked=0,
+            watched=0,
+            followed=False,
+            unfollowed=False,
+            job_name=None,
+            target=None
+        ):
         user = self.interacted_users.get(username, {})
         user[USER_LAST_INTERACTION] = str(datetime.now())
 
@@ -72,6 +82,21 @@ class Storage:
             user[USER_FOLLOWING_STATUS] = FollowingStatus.UNFOLLOWED.name.lower()
         else:
             user[USER_FOLLOWING_STATUS] = FollowingStatus.NONE.name.lower()
+
+        # Save only the last session_id
+        user["session_id"] = session_id
+
+        # Save only the last job_name and target
+        user["job_name"] = job_name
+        user["target"] = target
+
+        # Increase the value of liked or watched if we have already a value
+        user["liked"] = liked if "liked" not in user else (user["liked"] + liked)
+        user["watched"] = watched if "watched" not in user else (user["watched"] + watched)
+
+        # Update the followed or unfollowed boolean only if we have a real update
+        user["followed"] = followed if "followed" not in user or user["followed"] != followed else user["followed"]
+        user["unfollowed"] = unfollowed if "unfollowed" not in user or user["unfollowed"] != unfollowed else user["unfollowed"]
 
         self.interacted_users[username] = user
         self._update_file()

--- a/GramAddict/core/storage.py
+++ b/GramAddict/core/storage.py
@@ -6,6 +6,7 @@ from enum import Enum, unique
 
 logger = logging.getLogger(__name__)
 
+FILENAME_HISTORY_FILTER_USERS = "history_filters_users.json"
 FILENAME_INTERACTED_USERS = "interacted_users.json"
 USER_LAST_INTERACTION = "last_interaction"
 USER_FOLLOWING_STATUS = "following_status"
@@ -17,6 +18,10 @@ FILENAME_BLACKLIST = "blacklist.txt"
 class Storage:
     interacted_users_path = None
     interacted_users = {}
+
+    history_filter_users_path = None
+    history_filter_users = {}
+
     whitelist = []
     blacklist = []
 
@@ -29,14 +34,22 @@ class Storage:
 
         if not os.path.exists(my_username):
             os.makedirs(my_username)
+
         self.interacted_users_path = my_username + "/" + FILENAME_INTERACTED_USERS
         if os.path.exists(self.interacted_users_path):
             with open(self.interacted_users_path) as json_file:
                 self.interacted_users = json.load(json_file)
+
+        self.history_filter_users_path = my_username + "/" + FILENAME_HISTORY_FILTER_USERS
+        if os.path.exists(self.history_filter_users_path):
+            with open(self.history_filter_users_path) as json_file:
+                self.history_filter_users = json.load(json_file)
+
         whitelist_path = my_username + "/" + FILENAME_WHITELIST
         if os.path.exists(whitelist_path):
             with open(whitelist_path) as file:
                 self.whitelist = [line.rstrip() for line in file]
+
         blacklist_path = my_username + "/" + FILENAME_BLACKLIST
         if os.path.exists(blacklist_path):
             with open(blacklist_path) as file:
@@ -61,6 +74,22 @@ class Storage:
             return FollowingStatus.NOT_IN_LIST
         else:
             return FollowingStatus[user[USER_FOLLOWING_STATUS].upper()]
+
+    def add_filter_user(
+        self,
+        username,
+        profile_data,
+        skip_reason=None
+    ):
+        # user = self.history_filter_users.get(username, {})
+        user = profile_data.__dict__
+        user["follow_button_text"] = profile_data.follow_button_text.name
+        user["skip_reason"] = None if skip_reason is None else skip_reason.name
+        self.history_filter_users[username] = user
+        # self._update_file()
+        if self.history_filter_users_path is not None:
+            with open(self.history_filter_users_path, "w") as outfile:
+                json.dump(self.history_filter_users, outfile, indent=4, sort_keys=False)
 
     def add_interacted_user(
         self,

--- a/GramAddict/core/storage.py
+++ b/GramAddict/core/storage.py
@@ -63,16 +63,16 @@ class Storage:
             return FollowingStatus[user[USER_FOLLOWING_STATUS].upper()]
 
     def add_interacted_user(
-            self,
-            username,
-            session_id,
-            liked=0,
-            watched=0,
-            followed=False,
-            unfollowed=False,
-            job_name=None,
-            target=None
-        ):
+        self,
+        username,
+        session_id,
+        liked=0,
+        watched=0,
+        followed=False,
+        unfollowed=False,
+        job_name=None,
+        target=None,
+    ):
         user = self.interacted_users.get(username, {})
         user[USER_LAST_INTERACTION] = str(datetime.now())
 
@@ -92,11 +92,21 @@ class Storage:
 
         # Increase the value of liked or watched if we have already a value
         user["liked"] = liked if "liked" not in user else (user["liked"] + liked)
-        user["watched"] = watched if "watched" not in user else (user["watched"] + watched)
+        user["watched"] = (
+            watched if "watched" not in user else (user["watched"] + watched)
+        )
 
         # Update the followed or unfollowed boolean only if we have a real update
-        user["followed"] = followed if "followed" not in user or user["followed"] != followed else user["followed"]
-        user["unfollowed"] = unfollowed if "unfollowed" not in user or user["unfollowed"] != unfollowed else user["unfollowed"]
+        user["followed"] = (
+            followed
+            if "followed" not in user or user["followed"] != followed
+            else user["followed"]
+        )
+        user["unfollowed"] = (
+            unfollowed
+            if "unfollowed" not in user or user["unfollowed"] != unfollowed
+            else user["unfollowed"]
+        )
 
         self.interacted_users[username] = user
         self._update_file()

--- a/GramAddict/core/storage.py
+++ b/GramAddict/core/storage.py
@@ -66,10 +66,10 @@ class Storage:
         self,
         username,
         session_id,
-        liked=0,
-        watched=0,
         followed=False,
         unfollowed=False,
+        liked=0,
+        watched=0,
         job_name=None,
         target=None,
     ):

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -966,26 +966,26 @@ class ProfileView(ActionBarView):
 
     def getFollowButton(self):
         button_regex = f"{ClassName.BUTTON}|{ClassName.TEXT_VIEW}"
-        following_regex = "^Following|^Requested"
-        followback_regex = "^Follow Back$"
 
+        following_regex = "^Following|^Requested"
         following_button = self.device.find(
             classNameMatches=button_regex,
             clickable=True,
             textMatches=following_regex,
         )
+        if following_button.exists():
+            return following_button, FollowStatus.FOLLOWING
+
+        followback_regex = "^Follow Back$"
         followback_button = self.device.find(
             classNameMatches=button_regex,
             clickable=True,
             textMatches=followback_regex,
         )
-        if following_button.exists():
-            return following_button, FollowStatus.FOLLOWING
-
         if followback_button.exists():
             return followback_button, FollowStatus.FOLLOW_BACK
 
-        return None, None
+        return None, FollowStatus.FOLLOW
 
     def getUsername(self, error=True):
         title_view = self._getActionBarTitleBtn()

--- a/GramAddict/plugins/action_unfollow_followers.py
+++ b/GramAddict/plugins/action_unfollow_followers.py
@@ -284,7 +284,7 @@ class ActionUnfollowFollowers(Plugin):
                         == UnfollowRestriction.ANY_NON_FOLLOWERS,
                     )
                     if unfollowed:
-                        storage.add_interacted_user(username, unfollowed=True)
+                        storage.add_interacted_user(username, self.session_state.id, unfollowed=True)
                         on_unfollow()
                         unfollowed_count += 1
 

--- a/GramAddict/plugins/action_unfollow_followers.py
+++ b/GramAddict/plugins/action_unfollow_followers.py
@@ -284,7 +284,9 @@ class ActionUnfollowFollowers(Plugin):
                         == UnfollowRestriction.ANY_NON_FOLLOWERS,
                     )
                     if unfollowed:
-                        storage.add_interacted_user(username, self.session_state.id, unfollowed=True)
+                        storage.add_interacted_user(
+                            username, self.session_state.id, unfollowed=True
+                        )
                         on_unfollow()
                         unfollowed_count += 1
 

--- a/GramAddict/plugins/force_interact.dis
+++ b/GramAddict/plugins/force_interact.dis
@@ -130,6 +130,7 @@ class ForceIteract(Plugin):
                     stories_percentage,
                     int(args.follow_percentage),
                     int(args.follow_limit) if args.follow_limit else None,
+                    plugin,
                     storage,
                     profile_filter,
                     on_like,
@@ -150,6 +151,7 @@ class ForceIteract(Plugin):
         stories_percentage,
         follow_percentage,
         follow_limit,
+        current_job,
         storage,
         profile_filter,
         on_like,
@@ -193,7 +195,15 @@ class ForceIteract(Plugin):
         interaction_succeed, followed, number_of_liked, number_of_watched = interaction(
             device, username=username, can_follow=can_follow
         )
-        storage.add_interacted_user(username, self.session_state.id, followed=followed, liked=number_of_liked, watched=number_of_watched)
+        storage.add_interacted_user(
+            username,
+            self.session_state.id,
+            followed=followed,
+            liked=number_of_liked,
+            watched=number_of_watched,
+            job_name=current_job
+            target=username
+        )
         can_continue = on_interaction(succeed=interaction_succeed, followed=followed)
 
         logger.info("Unfollow @" + username)

--- a/GramAddict/plugins/force_interact.dis
+++ b/GramAddict/plugins/force_interact.dis
@@ -74,7 +74,7 @@ class ForceIteract(Plugin):
         self.sessions = sessions
         self.session_state = sessions[-1]
         self.ResourceID = resources(self.args.app_id)
-        profile_filter = Filter()
+        profile_filter = Filter(storage)
         self.current_mode = plugin
 
         # IMPORTANT: in each job we assume being on the top of the Profile tab already

--- a/GramAddict/plugins/force_interact.dis
+++ b/GramAddict/plugins/force_interact.dis
@@ -190,10 +190,10 @@ class ForceIteract(Plugin):
             )
         )
 
-        interaction_succeed, followed = interaction(
+        interaction_succeed, followed, number_of_liked, number_of_watched = interaction(
             device, username=username, can_follow=can_follow
         )
-        storage.add_interacted_user(username, followed=followed)
+        storage.add_interacted_user(username, self.session_state.id, followed=followed, liked=number_of_liked, watched=number_of_watched)
         can_continue = on_interaction(succeed=interaction_succeed, followed=followed)
 
         logger.info("Unfollow @" + username)

--- a/GramAddict/plugins/interact_blogger_followers.py
+++ b/GramAddict/plugins/interact_blogger_followers.py
@@ -316,12 +316,12 @@ class InteractBloggerFollowers(Plugin):
                             )
                         )
 
-                        interaction_succeed, followed = interaction(
+                        interaction_succeed, followed, number_of_liked, number_of_watched = interaction(
                             device, username=username, can_follow=can_follow
                         )
-                        storage.add_interacted_user(username, followed=followed)
+                        storage.add_interacted_user(username, self.session_state.id, followed=followed, liked=number_of_liked, watched=number_of_watched)
                         can_continue = on_interaction(
-                            succeed=interaction_succeed, followed=followed
+                            succeed=interaction_succeed, followed=followed,
                         )
 
                         if not can_continue:

--- a/GramAddict/plugins/interact_blogger_followers.py
+++ b/GramAddict/plugins/interact_blogger_followers.py
@@ -59,7 +59,7 @@ class InteractBloggerFollowers(Plugin):
         self.session_state = sessions[-1]
         self.args = configs.args
         self.ResourceID = resources(self.args.app_id)
-        profile_filter = Filter()
+        profile_filter = Filter(storage)
         self.current_mode = plugin
 
         # IMPORTANT: in each job we assume being on the top of the Profile tab already

--- a/GramAddict/plugins/interact_blogger_followers.py
+++ b/GramAddict/plugins/interact_blogger_followers.py
@@ -121,6 +121,7 @@ class InteractBloggerFollowers(Plugin):
                     stories_percentage,
                     int(self.args.follow_percentage),
                     int(self.args.follow_limit) if self.args.follow_limit else None,
+                    plugin,
                     storage,
                     profile_filter,
                     on_like,
@@ -148,6 +149,7 @@ class InteractBloggerFollowers(Plugin):
         stories_percentage,
         follow_percentage,
         follow_limit,
+        current_job,
         storage,
         profile_filter,
         on_like,
@@ -175,6 +177,12 @@ class InteractBloggerFollowers(Plugin):
             source=username,
             session_state=self.session_state,
         )
+        add_interacted_user = partial(
+            storage.add_interacted_user,
+            session_id=self.session_state.id,
+            job_name=current_job,
+            target=username,
+        )
 
         if not self.open_user_followers(device, username):
             return
@@ -185,6 +193,7 @@ class InteractBloggerFollowers(Plugin):
             interaction,
             is_follow_limit_reached,
             storage,
+            add_interacted_user,
             on_interaction,
             is_myself,
             skipped_list_limit=get_value(self.args.skipped_list_limit, None, 15),
@@ -242,6 +251,7 @@ class InteractBloggerFollowers(Plugin):
         interaction,
         is_follow_limit_reached,
         storage,
+        add_interacted_user,
         on_interaction,
         is_myself,
         skipped_list_limit,
@@ -324,9 +334,8 @@ class InteractBloggerFollowers(Plugin):
                         ) = interaction(
                             device, username=username, can_follow=can_follow
                         )
-                        storage.add_interacted_user(
+                        add_interacted_user(
                             username,
-                            self.session_state.id,
                             followed=followed,
                             liked=number_of_liked,
                             watched=number_of_watched,

--- a/GramAddict/plugins/interact_blogger_followers.py
+++ b/GramAddict/plugins/interact_blogger_followers.py
@@ -316,12 +316,24 @@ class InteractBloggerFollowers(Plugin):
                             )
                         )
 
-                        interaction_succeed, followed, number_of_liked, number_of_watched = interaction(
+                        (
+                            interaction_succeed,
+                            followed,
+                            number_of_liked,
+                            number_of_watched,
+                        ) = interaction(
                             device, username=username, can_follow=can_follow
                         )
-                        storage.add_interacted_user(username, self.session_state.id, followed=followed, liked=number_of_liked, watched=number_of_watched)
+                        storage.add_interacted_user(
+                            username,
+                            self.session_state.id,
+                            followed=followed,
+                            liked=number_of_liked,
+                            watched=number_of_watched,
+                        )
                         can_continue = on_interaction(
-                            succeed=interaction_succeed, followed=followed,
+                            succeed=interaction_succeed,
+                            followed=followed,
                         )
 
                         if not can_continue:

--- a/GramAddict/plugins/interact_hashtag_likers.py
+++ b/GramAddict/plugins/interact_hashtag_likers.py
@@ -297,10 +297,21 @@ class InteractHashtagLikers(Plugin):
                             == FollowingStatus.NOT_IN_LIST
                         )
 
-                        interaction_succeed, followed, number_of_liked, number_of_watched = interaction(
+                        (
+                            interaction_succeed,
+                            followed,
+                            number_of_liked,
+                            number_of_watched,
+                        ) = interaction(
                             device, username=username, can_follow=can_follow
                         )
-                        storage.add_interacted_user(username, self.session_state.id, followed=followed, liked=number_of_liked, watched=number_of_watched)
+                        storage.add_interacted_user(
+                            username,
+                            self.session_state.id,
+                            followed=followed,
+                            liked=number_of_liked,
+                            watched=number_of_watched,
+                        )
                         opened = True
                         can_continue = on_interaction(
                             succeed=interaction_succeed, followed=followed

--- a/GramAddict/plugins/interact_hashtag_likers.py
+++ b/GramAddict/plugins/interact_hashtag_likers.py
@@ -297,10 +297,10 @@ class InteractHashtagLikers(Plugin):
                             == FollowingStatus.NOT_IN_LIST
                         )
 
-                        interaction_succeed, followed = interaction(
+                        interaction_succeed, followed, number_of_liked, number_of_watched = interaction(
                             device, username=username, can_follow=can_follow
                         )
-                        storage.add_interacted_user(username, followed=followed)
+                        storage.add_interacted_user(username, self.session_state.id, followed=followed, liked=number_of_liked, watched=number_of_watched)
                         opened = True
                         can_continue = on_interaction(
                             succeed=interaction_succeed, followed=followed

--- a/GramAddict/plugins/interact_hashtag_likers.py
+++ b/GramAddict/plugins/interact_hashtag_likers.py
@@ -69,7 +69,7 @@ class InteractHashtagLikers(Plugin):
         self.sessions = sessions
         self.session_state = sessions[-1]
         self.args = configs.args
-        profile_filter = Filter()
+        profile_filter = Filter(storage)
         self.current_mode = plugin
 
         # IMPORTANT: in each job we assume being on the top of the Profile tab already

--- a/GramAddict/plugins/interact_hashtag_likers.py
+++ b/GramAddict/plugins/interact_hashtag_likers.py
@@ -194,6 +194,14 @@ class InteractHashtagLikers(Plugin):
             source=hashtag,
             session_state=self.session_state,
         )
+
+        add_interacted_user = partial(
+            storage.add_interacted_user,
+            session_id=self.session_state.id,
+            job_name=current_job,
+            target=hashtag,
+        )
+
         search_view = TabBarView(device).navigateToSearch()
         if not search_view.navigateToHashtag(hashtag):
             return
@@ -305,9 +313,8 @@ class InteractHashtagLikers(Plugin):
                         ) = interaction(
                             device, username=username, can_follow=can_follow
                         )
-                        storage.add_interacted_user(
+                        add_interacted_user(
                             username,
-                            self.session_state.id,
                             followed=followed,
                             liked=number_of_liked,
                             watched=number_of_watched,

--- a/GramAddict/plugins/interact_hashtag_posts.py
+++ b/GramAddict/plugins/interact_hashtag_posts.py
@@ -226,10 +226,19 @@ class InteractHashtagPosts(Plugin):
                 or storage.get_following_status(username) == FollowingStatus.NOT_IN_LIST
             )
 
-            interaction_succeed, followed, number_of_liked, number_of_watched = interaction(
-                device, username=username, can_follow=can_follow
+            (
+                interaction_succeed,
+                followed,
+                number_of_liked,
+                number_of_watched,
+            ) = interaction(device, username=username, can_follow=can_follow)
+            storage.add_interacted_user(
+                username,
+                self.session_state.id,
+                followed=followed,
+                liked=number_of_liked,
+                watched=number_of_watched,
             )
-            storage.add_interacted_user(username, self.session_state.id, followed=followed, liked=number_of_liked, watched=number_of_watched)
             can_continue = on_interaction(
                 succeed=interaction_succeed, followed=followed
             )

--- a/GramAddict/plugins/interact_hashtag_posts.py
+++ b/GramAddict/plugins/interact_hashtag_posts.py
@@ -203,6 +203,14 @@ class InteractHashtagPosts(Plugin):
             source=hashtag,
             session_state=self.session_state,
         )
+
+        add_interacted_user = partial(
+            storage.add_interacted_user,
+            session_id=self.session_state.id,
+            job_name=current_job,
+            target=hashtag,
+        )
+
         search_view = TabBarView(device).navigateToSearch()
         if not search_view.navigateToHashtag(hashtag):
             return
@@ -232,9 +240,8 @@ class InteractHashtagPosts(Plugin):
                 number_of_liked,
                 number_of_watched,
             ) = interaction(device, username=username, can_follow=can_follow)
-            storage.add_interacted_user(
+            add_interacted_user(
                 username,
-                self.session_state.id,
                 followed=followed,
                 liked=number_of_liked,
                 watched=number_of_watched,

--- a/GramAddict/plugins/interact_hashtag_posts.py
+++ b/GramAddict/plugins/interact_hashtag_posts.py
@@ -76,7 +76,7 @@ class InteractHashtagPosts(Plugin):
         self.sessions = sessions
         self.session_state = sessions[-1]
         self.args = configs.args
-        profile_filter = Filter()
+        profile_filter = Filter(storage)
         self.current_mode = plugin
 
         # IMPORTANT: in each job we assume being on the top of the Profile tab already

--- a/GramAddict/plugins/interact_hashtag_posts.py
+++ b/GramAddict/plugins/interact_hashtag_posts.py
@@ -226,10 +226,10 @@ class InteractHashtagPosts(Plugin):
                 or storage.get_following_status(username) == FollowingStatus.NOT_IN_LIST
             )
 
-            interaction_succeed, followed = interaction(
+            interaction_succeed, followed, number_of_liked, number_of_watched = interaction(
                 device, username=username, can_follow=can_follow
             )
-            storage.add_interacted_user(username, followed=followed)
+            storage.add_interacted_user(username, self.session_state.id, followed=followed, liked=number_of_liked, watched=number_of_watched)
             can_continue = on_interaction(
                 succeed=interaction_succeed, followed=followed
             )

--- a/GramAddict/plugins/interact_usernames.py
+++ b/GramAddict/plugins/interact_usernames.py
@@ -195,10 +195,21 @@ class InteractUsernames(Plugin):
                                 == FollowingStatus.NOT_IN_LIST
                             )
 
-                            interaction_succeed, followed, number_of_liked, number_of_watched = interaction(
+                            (
+                                interaction_succeed,
+                                followed,
+                                number_of_liked,
+                                number_of_watched,
+                            ) = interaction(
                                 device, username=username, can_follow=can_follow
                             )
-                            storage.add_interacted_user(username, self.session_state.id, followed=followed, liked=number_of_liked, watched=number_of_watched)
+                            storage.add_interacted_user(
+                                username,
+                                self.session_state.id,
+                                followed=followed,
+                                liked=number_of_liked,
+                                watched=number_of_watched,
+                            )
                             can_continue = on_interaction(
                                 succeed=interaction_succeed, followed=followed
                             )

--- a/GramAddict/plugins/interact_usernames.py
+++ b/GramAddict/plugins/interact_usernames.py
@@ -158,12 +158,21 @@ class InteractUsernames(Plugin):
             session_state=self.session_state,
             current_mode=self.current_mode,
         )
+
         is_follow_limit_reached = partial(
             is_follow_limit_reached_for_source,
             follow_limit=follow_limit,
             source=current_file,
             session_state=self.session_state,
         )
+
+        add_interacted_user = partial(
+            storage.add_interacted_user,
+            session_id=self.session_state.id,
+            job_name=current_job,
+            target=current_file,
+        )
+
         need_to_refresh = True
         if path.isfile(current_file):
             with open(current_file, "r") as f:
@@ -203,9 +212,8 @@ class InteractUsernames(Plugin):
                             ) = interaction(
                                 device, username=username, can_follow=can_follow
                             )
-                            storage.add_interacted_user(
+                            add_interacted_user(
                                 username,
-                                self.session_state.id,
                                 followed=followed,
                                 liked=number_of_liked,
                                 watched=number_of_watched,

--- a/GramAddict/plugins/interact_usernames.py
+++ b/GramAddict/plugins/interact_usernames.py
@@ -51,7 +51,7 @@ class InteractUsernames(Plugin):
         self.device_id = configs.args.device
         self.sessions = sessions
         self.session_state = sessions[-1]
-        profile_filter = Filter()
+        profile_filter = Filter(storage)
         self.current_mode = plugin
 
         file_list = [file for file in (self.args.interact_from_file)]

--- a/GramAddict/plugins/interact_usernames.py
+++ b/GramAddict/plugins/interact_usernames.py
@@ -195,10 +195,10 @@ class InteractUsernames(Plugin):
                                 == FollowingStatus.NOT_IN_LIST
                             )
 
-                            interaction_succeed, followed = interaction(
+                            interaction_succeed, followed, number_of_liked, number_of_watched = interaction(
                                 device, username=username, can_follow=can_follow
                             )
-                            storage.add_interacted_user(username, followed=followed)
+                            storage.add_interacted_user(username, self.session_state.id, followed=followed, liked=number_of_liked, watched=number_of_watched)
                             can_continue = on_interaction(
                                 succeed=interaction_succeed, followed=followed
                             )

--- a/GramAddict/plugins/like_from_urls.py
+++ b/GramAddict/plugins/like_from_urls.py
@@ -90,7 +90,7 @@ class LikeFromURLs(Plugin):
                             )
                             if like_succeed:
                                 logger.info("Back to profile")
-                                storage.add_interacted_user(username)
+                                storage.add_interacted_user(username, self.session_state.id, liked=1)
                                 self.device.back()
                                 random_sleep()
                     else:

--- a/GramAddict/plugins/like_from_urls.py
+++ b/GramAddict/plugins/like_from_urls.py
@@ -90,7 +90,9 @@ class LikeFromURLs(Plugin):
                             )
                             if like_succeed:
                                 logger.info("Back to profile")
-                                storage.add_interacted_user(username, self.session_state.id, liked=1)
+                                storage.add_interacted_user(
+                                    username, self.session_state.id, liked=1
+                                )
                                 self.device.back()
                                 random_sleep()
                     else:


### PR DESCRIPTION
# Description

:gift: As requested by #139 we have add more data in **interacted_users.json** and we have also a new file called **history_filters_users.json**. Both are located inside _your_username/_ folder.

**interacted_users.json**
```js
"username": {
        "last_interaction": "2021-01-02 16:05:21.586260",
        "following_status": "none",
        "session_id": "22fb00ed-0339-4c5b-b14f-968ba6f16969",  // [string] Refence id for session.json 
        "job_name": "hashtag-likers-top",  // [string] Current job name
        "target": "#webdeveloper",  // [string] The target or source, it can be a place (after #169), hashtags or username/blogger
        "liked": 1,  // [number] Count of posts liked
        "watched": 0,  // [number] Count of stories watched
        "followed": false,  // [boolean] If in this job the script have follow the user
        "unfollowed": false  // [boolean] If in this job the script have unfollow the user
}
```

:gift: In the Issue #139 was requested also the field `Private, (binary, if the user is private)`
All the data collected by the filter are now writes in **history_filters_users.json**, here an example:

```js
"username": {
        "datetime": "2021-01-02 15:41:15.938211",
        "followers": 864,  // [number] Count of followers
        "followings": 499,  // [number] Count of following
        "follow_button_text": "FOLLOW",  // [string] Text of buttonFollow it can be: FOLLOWING, FOLLOW_BACK, FOLLOW
        "is_private": true,  // [boolean/none] Privacy's user
        "has_business_category": false,  // [boolean] If the user have a business category
        "posts_count": 235,  // [number] Count of posts
        "biography": "Help so............ou back.",  // [string] The user biography
        "fullname": "lalalalaal",  // [string] User fullname  
        "potency_ratio": 1.7314629258517034,  // [number] Followers / Following = Potency ratio
        "skip_reason": "POTENCY_RATIO"  // [string] The reason why the bot have skipped the user
    },
```
:gift: :cat2: With the **skip_reason** now we also know why the bot have skipped the user. The possibile reason are (i think they don't need exaplaination):
 - `YOU_FOLLOW`
- `FOLLOW_YOU`
- `IS_PRIVATE`
- `UNKNOWN_PRIVACY`
- `LT_FOLLOWERS`
- `GT_FOLLOWERS`
- `LT_FOLLOWINGS`
- `GT_FOLLOWINGS`
- `POTENCY_RATIO`
- `UNDEFINED_FOLLOWERS_FOLLOWING`
- `HAS_BUSINESS`
- `HAS_NON_BUSINESS`
- `NOT_ENOUGH_POSTS`
- `BLACKLISTED_WORD`
- `MISSING_MANDATORY_WORDS`
- `ALPHABET_NOT_MATCH`
- `ALPHABET_NAME_NOT_MATCH`


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

_Please some one help me with these checkbox_
## Little disclaimer
It's probable that this PR It's not easy to merge with #169 (and vice-versa). So we need a 3th branch for merge al PRs. That's why In this PR I have edited the files **interact_hashtag_posts.py,  interact_hashtag_likers.py** and the use of **Storage**, **add_interacted_user** (in #169 the call of this method was moved in another file), **Filter** and so on.  

# How Has This Been Tested?

Just a couple of test with all available jobs ....

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have tested my code in every way I can think of to prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules