### PR TITLE
🐛 Fix hashtags search on LowerDPI devices + Check if the keyboard is open with adb

### DIFF
--- a/GramAddict/__init__.py
+++ b/GramAddict/__init__.py
@@ -110,6 +110,7 @@ def run():
         open_instagram(device, configs.args.screen_record)
 
         try:
+            random_sleep()
             profileView = TabBarView(device).navigateToProfile()
             random_sleep()
             if configs.args.username is not None:

--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -137,6 +137,14 @@ class DeviceFacade:
         flag = search("mDreamingLockscreen=(true|false)", data)
         return True if flag.group(1) == "true" else False
 
+    def is_keyboard_show(self):
+        status = popen(
+            f"adb {'' if self.device_id is None else ('-s '+ self.device_id)} shell dumpsys input_method"
+        )
+        data = status.read()
+        flag = search("mInputShown=(true|false)", data)
+        return True if flag.group(1) == "true" else False
+
     def is_alive(self):
         # v2 only - for atx_agent
         return self.deviceV2._is_alive()

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -314,12 +314,9 @@ class SearchView:
         else:
             delta = 375
         if swipe_to_accounts:
-            logger.debug("Swipe up to close the keyboard if present")
-            UniversalActions(self.device)._swipe_points(
-                direction=Direction.UP,
-                start_point_y=randint(delta + 10, delta + 150),
-                delta_y=randint(50, 100),
-            )
+            if self.device.is_keyboard_show() is True:
+                logger.debug("The keyboard is currently open. Press back to close")
+                self.device.back()
             random_sleep(1, 2)
             DeviceFacade.swipe(self.device, DeviceFacade.Direction.LEFT, 0.8)
             random_sleep(1, 2)
@@ -331,12 +328,9 @@ class SearchView:
                 searched_user_recent.click()
                 return ProfileView(self.device, is_own_profile=False)
             search_edit_text.set_text(username)
-        logger.debug("Swipe up to close the keyboard if present")
-        UniversalActions(self.device)._swipe_points(
-            direction=Direction.UP,
-            start_point_y=randint(delta + 10, delta + 150),
-            delta_y=randint(50, 100),
-        )
+            if self.device.is_keyboard_show() is True:
+                logger.debug("The keyboard is currently open. Press back to close")
+                self.device.back()
         random_sleep(1, 2)
         username_view = self._getUsernameRow(username)
         if not username_view.exists(True):
@@ -371,14 +365,9 @@ class SearchView:
         else:
             delta = 375
 
-        logger.debug(
-            "Swipe up to close the keyboard if present"
-        )  # Why not press the back button?
-        UniversalActions(self.device)._swipe_points(
-            direction=Direction.UP,
-            start_point_y=randint(delta + 10, delta + 150),
-            delta_y=randint(50, 100),
-        )
+        if self.device.is_keyboard_show() is True:
+            logger.debug("The keyboard is currently open. Press back to close")
+            self.device.back()
         random_sleep(1, 2)
         # check if that hashtag already exists in the recent search list -> act as human
         hashtag_view_recent = self._getHashtagRow(hashtag[1:])
@@ -394,7 +383,6 @@ class SearchView:
         random_sleep(4, 8)
 
         if not hashtag_view.exists():
-            # Before abort try to close the keyboard and to a little swipe down
             if self.device.is_keyboard_show() is True:
                 logger.debug("The keyboard is currently open. Press back to close")
                 self.device.back()

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -371,7 +371,9 @@ class SearchView:
         else:
             delta = 375
 
-        logger.debug("Swipe up to close the keyboard if present")  # Why not press the back button?
+        logger.debug(
+            "Swipe up to close the keyboard if present"
+        )  # Why not press the back button?
         UniversalActions(self.device)._swipe_points(
             direction=Direction.UP,
             start_point_y=randint(delta + 10, delta + 150),

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -306,9 +306,6 @@ class SearchView:
         search_edit_text = self._getSearchEditText()
         search_edit_text.click()
         random_sleep(1, 2)
-        tabbar_container = self.device.find(
-            resourceId=ResourceID.FIXED_TABBAR_TABS_CONTAINER
-        )
         if swipe_to_accounts:
             if self.device.is_keyboard_show() is True:
                 logger.debug("The keyboard is currently open. Press back to close")

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -914,8 +914,8 @@ class OpenedPostView:
             classNameMatches=ClassName.BUTTON_OR_TEXTVIEW_REGEX,
         )
         # UIA1 doesn't use .get_text()
-        if text.exists() and type(text) != str:
-            text = text.get_text()
+        if type(text) != str:
+            text = text.get_text() if text.exists() else ""
         return True if text == "Following" or text == "Requested" else False
 
 

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -309,10 +309,6 @@ class SearchView:
         tabbar_container = self.device.find(
             resourceId=ResourceID.FIXED_TABBAR_TABS_CONTAINER
         )
-        if tabbar_container.exists(True):
-            delta = tabbar_container.get_bounds()["bottom"]
-        else:
-            delta = 375
         if swipe_to_accounts:
             if self.device.is_keyboard_show() is True:
                 logger.debug("The keyboard is currently open. Press back to close")


### PR DESCRIPTION
:gift: Create a method for check if the keyboard is open or not:
`adb shell dumpsys input_method | grep mInputShown`

![image](https://user-images.githubusercontent.com/14061593/103637336-a2f46800-4f4b-11eb-826d-f7ebac642742.png)

:cat2: :bug: On device with LowerDPI the search function not work correctly. If the keyboard is open, close and then do a little swipe DOWN

![2021-01-05_11-45](https://user-images.githubusercontent.com/14061593/103637453-cd462580-4f4b-11eb-9f19-25662ea8abd4.png)

:heavy_plus_sign: Why we don't use go back instead of swipe UP to close the keyboard? (for example https://github.com/GramAddict/bot/blob/master/GramAddict/core/views.py#L315) I mean elsewhere in the code, a good idea It's to create a method: 

```python
def close_keyboard_if_is_open(self)
    if self.device.is_keyboard_show():
        self.device.back()
```
