### PR TITLE
Use Gramaddict as module.

### DIFF
--- a/GramAddict/__init__.py
+++ b/GramAddict/__init__.py
@@ -1,5 +1,7 @@
 from GramAddict.core.bot_flow import start_bot
 
 
-def run():
-    start_bot()
+def run(**kwargs):
+    start_bot(**kwargs)
+
+

--- a/GramAddict/__init__.py
+++ b/GramAddict/__init__.py
@@ -3,5 +3,3 @@ from GramAddict.core.bot_flow import start_bot
 
 def run(**kwargs):
     start_bot(**kwargs)
-
-

--- a/GramAddict/core/bot_flow.py
+++ b/GramAddict/core/bot_flow.py
@@ -58,7 +58,7 @@ def start_bot(**kwargs):
     # Logging initialization
     configure_logger(configs.debug, configs.username)
     logger = logging.getLogger(__name__)
-    if "--config" not in configs.args and "config" not in configs.args:
+    if "config" not in configs.args:
         logger.info(
             "We strongly recommend to use a config.yml file. Follow these links for more details: https://docs.gramaddict.org/#/configuration and https://github.com/GramAddict/bot/tree/master/config-examples",
             extra={"color": f"{Fore.GREEN}{Style.BRIGHT}"},

--- a/GramAddict/core/bot_flow.py
+++ b/GramAddict/core/bot_flow.py
@@ -48,14 +48,17 @@ from GramAddict.core.views import load_config as load_views
 TESTED_IG_VERSION = "202.0.0.37.123"
 
 
-def start_bot():
+def start_bot(**kwargs):
     # Pre-Load Config
-    configs = Config(first_run=True)
+    if not kwargs:
+        configs = Config(first_run=True)
+    else:
+        configs = Config(first_run=True, module=True, **kwargs)
 
     # Logging initialization
     configure_logger(configs.debug, configs.username)
     logger = logging.getLogger(__name__)
-    if "--config" not in configs.args:
+    if "--config" not in configs.args and "config" not in configs.args:
         logger.info(
             "We strongly recommend to use a config.yml file. Follow these links for more details: https://docs.gramaddict.org/#/configuration and https://github.com/GramAddict/bot/tree/master/config-examples",
             extra={"color": f"{Fore.GREEN}{Style.BRIGHT}"},
@@ -78,7 +81,6 @@ def start_bot():
     # Load Config
     configs.load_plugins()
     configs.parse_args()
-
     # Some plugins need config values without being passed
     # through. Because we do a weird config/argparse hybrid,
     # we need to load the configs in a weird way
@@ -147,7 +149,7 @@ def start_bot():
                 running_ig_version = get_instagram_version()
                 logger.info(f"Instagram version: {running_ig_version}")
                 if tuple(running_ig_version.split(".")) > tuple(
-                    TESTED_IG_VERSION.split(".")
+                        TESTED_IG_VERSION.split(".")
                 ):
                     logger.info(
                         f"You have a newer version of IG then the one we tested! (Tested version: {TESTED_IG_VERSION})",
@@ -183,10 +185,10 @@ def start_bot():
             break
 
         if (
-            session_state.my_username is None
-            or session_state.my_posts_count is None
-            or session_state.my_followers_count is None
-            or session_state.my_following_count is None
+                session_state.my_username is None
+                or session_state.my_posts_count is None
+                or session_state.my_followers_count is None
+                or session_state.my_following_count is None
         ):
             logger.critical(
                 "Could not get one of the following from your profile: username, # of posts, # of followers, # of followings. This is typically due to a soft ban. Review the crash screenshot to see if this is the case."
@@ -209,7 +211,7 @@ def start_bot():
         logger.info(report_string, extra={"color": f"{Style.BRIGHT}"})
         if configs.args.repeat:
             logger.info(
-                f"You have {total_sessions+1-len(sessions) if total_sessions > 0 else 'infinite'} session(s) left. You can stop the bot by pressing CTRL+C in console.",
+                f"You have {total_sessions + 1 - len(sessions) if total_sessions > 0 else 'infinite'} session(s) left. You can stop the bot by pressing CTRL+C in console.",
                 extra={"color": f"{Style.BRIGHT}{Fore.YELLOW}"},
             )
             sleep(3)
@@ -239,7 +241,7 @@ def start_bot():
                 )
                 break
             if not session_state.check_limit(
-                configs.args, limit_type=session_state.Limit.ALL, output=True
+                    configs.args, limit_type=session_state.Limit.ALL, output=True
             ):
                 logger.info(
                     f"Current job: {plugin}",
@@ -303,7 +305,7 @@ def start_bot():
             )
             if inside_working_hours:
                 time_left = (
-                    get_value(configs.args.repeat, "Sleep for {} minutes.", 180) * 60
+                        get_value(configs.args.repeat, "Sleep for {} minutes.", 180) * 60
                 )
                 print_telegram_reports(
                     configs,
@@ -313,7 +315,7 @@ def start_bot():
                     time_left,
                 )
                 logger.info(
-                    f'Next session will start at: {(datetime.now()+ timedelta(seconds=time_left)).strftime("%H:%M:%S (%Y/%m/%d)")}.'
+                    f'Next session will start at: {(datetime.now() + timedelta(seconds=time_left)).strftime("%H:%M:%S (%Y/%m/%d)")}.'
                 )
                 try:
                     sleep(time_left)

--- a/GramAddict/core/bot_flow.py
+++ b/GramAddict/core/bot_flow.py
@@ -149,7 +149,7 @@ def start_bot(**kwargs):
                 running_ig_version = get_instagram_version()
                 logger.info(f"Instagram version: {running_ig_version}")
                 if tuple(running_ig_version.split(".")) > tuple(
-                        TESTED_IG_VERSION.split(".")
+                    TESTED_IG_VERSION.split(".")
                 ):
                     logger.info(
                         f"You have a newer version of IG then the one we tested! (Tested version: {TESTED_IG_VERSION})",
@@ -185,10 +185,10 @@ def start_bot(**kwargs):
             break
 
         if (
-                session_state.my_username is None
-                or session_state.my_posts_count is None
-                or session_state.my_followers_count is None
-                or session_state.my_following_count is None
+            session_state.my_username is None
+            or session_state.my_posts_count is None
+            or session_state.my_followers_count is None
+            or session_state.my_following_count is None
         ):
             logger.critical(
                 "Could not get one of the following from your profile: username, # of posts, # of followers, # of followings. This is typically due to a soft ban. Review the crash screenshot to see if this is the case."
@@ -241,7 +241,7 @@ def start_bot(**kwargs):
                 )
                 break
             if not session_state.check_limit(
-                    configs.args, limit_type=session_state.Limit.ALL, output=True
+                configs.args, limit_type=session_state.Limit.ALL, output=True
             ):
                 logger.info(
                     f"Current job: {plugin}",
@@ -305,7 +305,7 @@ def start_bot(**kwargs):
             )
             if inside_working_hours:
                 time_left = (
-                        get_value(configs.args.repeat, "Sleep for {} minutes.", 180) * 60
+                    get_value(configs.args.repeat, "Sleep for {} minutes.", 180) * 60
                 )
                 print_telegram_reports(
                     configs,

--- a/GramAddict/core/config.py
+++ b/GramAddict/core/config.py
@@ -145,13 +145,12 @@ class Config:
                     self.parser.print_help()
                     exit(0)
         if self.module:
-            arg_str = ''
+            arg_str = ""
             for k, v in self.args.items():
-                new_key = k.replace('_', '-')
-                new_key = ' --' + new_key
-                arg_str += new_key + ' ' + v
-            self.args, self.unknown_args = self.parser.parse_known_args(
-                args=arg_str)
+                new_key = k.replace("_", "-")
+                new_key = " --" + new_key
+                arg_str += new_key + " " + v
+            self.args, self.unknown_args = self.parser.parse_known_args(args=arg_str)
         else:
             self.args, self.unknown_args = self.parser.parse_known_args()
         if "run" in self.unknown_args:


### PR DESCRIPTION
Some small changes to use Gramaddict as module.
You can import Gramaddict in a python file and pass arguments as keyword args
Example:

`Grammadict.run(config='config file location', username'test')`
You have to rename args removing   -- and replace - with _