### PR TITLE
fix: use monkey instead of am start

### DIFF
--- a/GramAddict/core/utils.py
+++ b/GramAddict/core/utils.py
@@ -234,7 +234,7 @@ def open_instagram(device):
 
     def call_ig():
         try:
-            return device.deviceV2.app_start(app_id)
+            return device.deviceV2.app_start(app_id, use_monkey=True)
         except uiautomator2.exceptions.BaseError as exc:
             return exc
 


### PR DESCRIPTION
there is a problem starting the last Instagram app due to an atx-agent bug, https://github.com/openatx/atx-agent/pull/111
In the meantime, we will use monkey to start app