### PR TITLE
Fix for bug #285 and possibly #301

### DIFF
--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -131,7 +131,6 @@ class DeviceFacade:
     def back(self, modulable: bool = True):
         logger.debug("Press back button.")
         self.deviceV2.press("back")
-
         random_sleep(modulable=modulable)
 
     def start_screenrecord(self, output="debug_0000.mp4", fps=20):

--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -131,22 +131,8 @@ class DeviceFacade:
     def back(self, modulable: bool = True):
         logger.debug("Press back button.")
         self.deviceV2.press("back")
-        # attempt to fix bug #367 - not enough waiting time for the followers list to load?
+
         random_sleep(modulable=modulable)
-
-        selectors = [
-            {'resourceId': 'com.instagram.android:id/follow_list_container'},
-            {'resourceId': 'com.instagram.android:id/row_user_container_base'},
-            {'resourceId': 'com.instagram.android:id/recommended_user_row_content_identifier'}
-        ]
-
-        # Wait for each element
-        for selector in selectors:
-            logger.info(f"[Trying to avoid bug #367] Waiting for element with selector {selector} to appear.")
-            if not wait_for_element(self.deviceV2, selector, timeout=3):
-                logger.debug(f"Element with selector {selector} was not found within 3 seconds.")
-                # Handle the case where the element is not found
-                # You can either break, continue, or take some other action
 
     def start_screenrecord(self, output="debug_0000.mp4", fps=20):
         import imageio

--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -143,8 +143,8 @@ class DeviceFacade:
         # Wait for each element
         for selector in selectors:
             logger.info(f"[Trying to avoid bug #367] Waiting for element with selector {selector} to appear.")
-            if not wait_for_element(self.deviceV2, selector, timeout=5):
-                logger.info(f"Element with selector {selector} was not found within 5 seconds.")
+            if not wait_for_element(self.deviceV2, selector, timeout=3):
+                logger.info(f"Element with selector {selector} was not found within 3 seconds.")
                 # Handle the case where the element is not found
                 # You can either break, continue, or take some other action
 

--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -1,5 +1,6 @@
 import logging
 import string
+import time
 from datetime import datetime
 from enum import Enum, auto
 from inspect import stack
@@ -12,7 +13,7 @@ from typing import Optional
 
 import uiautomator2
 
-from GramAddict.core.utils import random_sleep
+from GramAddict.core.utils import random_sleep, wait_for_element
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +131,21 @@ class DeviceFacade:
     def back(self, modulable: bool = True):
         logger.debug("Press back button.")
         self.deviceV2.press("back")
+        # attempt to fix bug #367 - not enough waiting time for the followers list to load?
         random_sleep(modulable=modulable)
+
+        selectors = [
+            {'resourceId': 'com.instagram.android:id/follow_list_container'},
+            {'resourceId': 'com.instagram.android:id/row_user_container_base'},
+            {'resourceId': 'com.instagram.android:id/recommended_user_row_content_identifier'}
+        ]
+
+        # Wait for each element
+        for selector in selectors:
+            if not wait_for_element(self.deviceV2, selector):
+                logger.debug(f"Element with selector {selector} not found within 15 seconds.")
+                # Handle the case where the element is not found
+                # You can either break, continue, or take some other action
 
     def start_screenrecord(self, output="debug_0000.mp4", fps=20):
         import imageio

--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -144,7 +144,7 @@ class DeviceFacade:
         for selector in selectors:
             logger.info(f"[Trying to avoid bug #367] Waiting for element with selector {selector} to appear.")
             if not wait_for_element(self.deviceV2, selector, timeout=3):
-                logger.info(f"Element with selector {selector} was not found within 3 seconds.")
+                logger.debug(f"Element with selector {selector} was not found within 3 seconds.")
                 # Handle the case where the element is not found
                 # You can either break, continue, or take some other action
 

--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -143,7 +143,7 @@ class DeviceFacade:
         # Wait for each element
         for selector in selectors:
             if not wait_for_element(self.deviceV2, selector):
-                logger.debug(f"Element with selector {selector} not found within 15 seconds.")
+                logger.debug(f"[Trying to avoid bug #367] Element with selector {selector} not found within 15 seconds.")
                 # Handle the case where the element is not found
                 # You can either break, continue, or take some other action
 

--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -135,9 +135,9 @@ class DeviceFacade:
         random_sleep(modulable=modulable)
 
         selectors = [
-            #{'resourceId': 'com.instagram.android:id/follow_list_container'},
+            {'resourceId': 'com.instagram.android:id/follow_list_container'},
             {'resourceId': 'com.instagram.android:id/row_user_container_base'},
-            #{'resourceId': 'com.instagram.android:id/recommended_user_row_content_identifier'}
+            {'resourceId': 'com.instagram.android:id/recommended_user_row_content_identifier'}
         ]
 
         # Wait for each element

--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -143,7 +143,7 @@ class DeviceFacade:
         # Wait for each element
         for selector in selectors:
             if not wait_for_element(self.deviceV2, selector):
-                logger.debug(f"[Trying to avoid bug #367] Element with selector {selector} not found within 15 seconds.")
+                logger.info(f"[Trying to avoid bug #367] Element with selector {selector} not found within 15 seconds.")
                 # Handle the case where the element is not found
                 # You can either break, continue, or take some other action
 

--- a/GramAddict/core/device_facade.py
+++ b/GramAddict/core/device_facade.py
@@ -135,15 +135,16 @@ class DeviceFacade:
         random_sleep(modulable=modulable)
 
         selectors = [
-            {'resourceId': 'com.instagram.android:id/follow_list_container'},
+            #{'resourceId': 'com.instagram.android:id/follow_list_container'},
             {'resourceId': 'com.instagram.android:id/row_user_container_base'},
-            {'resourceId': 'com.instagram.android:id/recommended_user_row_content_identifier'}
+            #{'resourceId': 'com.instagram.android:id/recommended_user_row_content_identifier'}
         ]
 
         # Wait for each element
         for selector in selectors:
-            if not wait_for_element(self.deviceV2, selector):
-                logger.info(f"[Trying to avoid bug #367] Element with selector {selector} not found within 15 seconds.")
+            logger.info(f"[Trying to avoid bug #367] Waiting for element with selector {selector} to appear.")
+            if not wait_for_element(self.deviceV2, selector, timeout=5):
+                logger.info(f"Element with selector {selector} was not found within 5 seconds.")
                 # Handle the case where the element is not found
                 # You can either break, continue, or take some other action
 

--- a/GramAddict/core/navigation.py
+++ b/GramAddict/core/navigation.py
@@ -68,18 +68,20 @@ def nav_to_hashtag_or_place(device, target, current_job):
 
     TargetView = HashTagView if current_job.startswith("hashtag") else PlacesView
 
-    if current_job.endswith("recent"):
-        logger.info("Switching to Recent tab.")
-        recent_tab = TargetView(device)._getRecentTab()
-        if recent_tab.exists(Timeout.MEDIUM):
-            recent_tab.click()
-        else:
-            return False
+    # when searching for a hashtag, the recent tab is not available anymore in version 263.2.0.19.104
 
-        if UniversalActions(device)._check_if_no_posts():
-            UniversalActions(device)._reload_page()
-            if UniversalActions(device)._check_if_no_posts():
-                return False
+    # if current_job.endswith("recent"):
+    #     logger.info("Switching to Recent tab.")
+    #     recent_tab = TargetView(device)._getRecentTab()
+    #     if recent_tab.exists(Timeout.MEDIUM):
+    #         recent_tab.click()
+    #     else:
+    #         return False
+    #
+    #     if UniversalActions(device)._check_if_no_posts():
+    #         UniversalActions(device)._reload_page()
+    #         if UniversalActions(device)._check_if_no_posts():
+    #             return False
 
     result_view = TargetView(device)._getRecyclerView()
     FistImageInView = TargetView(device)._getFistImageView(result_view)

--- a/GramAddict/core/utils.py
+++ b/GramAddict/core/utils.py
@@ -731,6 +731,15 @@ def inspect_current_view(user_list) -> Tuple[int, int]:
     logger.debug(f"There are {n_users} users fully visible in that view.")
     return row_height, n_users
 
+# used by back function device_facade.py - attempt to fix bug #367
+def wait_for_element(device, selector, timeout=15):
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        if device(**selector).exists:
+            return True
+        time.sleep(1)
+    return False
+
 
 class ActionBlockedError(Exception):
     pass

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -922,6 +922,7 @@ class PostsViewList:
             # workaround test for bug #285/#301
             if obj_count == 0:
                 media_type = MediaType.REEL # it might be better to set it to UNKNOWN
+                logger.info("Activating workaround test for Bug #285 - switching to REEL media type")
             # end of workaround test
         return media_type, obj_count
 

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -919,6 +919,10 @@ class PostsViewList:
             )
             obj_count = n_photos + n_videos
             media_type = MediaType.CAROUSEL
+            # workaround test for bug #285/#301
+            if obj_count == 0:
+                media_type = MediaType.REEL # it might be better to set it to UNKNOWN
+            # end of workaround test
         return media_type, obj_count
 
     def _like_in_post_view(


### PR DESCRIPTION
# Description

 the bot sometimes detects reels as carousels with 0 items and stops responding for hours until it crashes

refer to:
https://github.com/GramAddict/bot/issues/285#issuecomment-1248614823
https://github.com/GramAddict/bot/issues/301#issuecomment-1650826718

Fixes # (issue)

## In a case where a carousel is detected with 0 items - change the media type detected to Reel

# How Has This Been Tested?

The test was running for several sessions. A carousel with 0 items was detected and the bot did not crash. 

**Test Configuration**:
* OS - Ubuntu 22
* GramAddict Version: 3.2.9
* Device Model or Emulator: Android Studio
* Android Verison: 9.0
* Instagram Version: 263.2.0.19.104

# Checklist:

Needs testing in more configurations?