### PR TITLE
Fix recent post by hashtag

### DIFF
--- a/GramAddict/core/navigation.py
+++ b/GramAddict/core/navigation.py
@@ -70,10 +70,8 @@ def nav_to_hashtag_or_place(device, target, current_job):
 
     if current_job.endswith("recent"):
         logger.info("Switching to Recent tab.")
-        recent_tab = TargetView(device)._getRecentTab()
-        if recent_tab.exists(Timeout.MEDIUM):
-            recent_tab.click()
-        else:
+        recent_tab_exists = TargetView(device)._navigateToRecentTab()
+        if not recent_tab_exists:
             return False
 
         if UniversalActions(device)._check_if_no_posts():

--- a/GramAddict/core/resources.py
+++ b/GramAddict/core/resources.py
@@ -223,6 +223,8 @@ class TabBarText:
     POSTS_CONTENT_DESC = "Grid View"
     PROFILE_CONTENT_DESC = "Profile"
     RECENT_CONTENT_DESC = "Recent"
+    FILTER_CONTENT = "Filter"
+    FILTER_RECENT_CONTENT = "Recent top posts"
     REELS_CONTENT_DESC = "Reels"
     SEARCH_CONTENT_DESC = "Search and Explore"
 

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -243,19 +243,30 @@ class HashTagView:
             logger.debug("First image in view doesn't exists.")
         return obj
 
-    def _getRecentTab(self):
+    def _navigateToRecentTab(self):
         obj = self.device.find(
-            className=ClassName.TEXT_VIEW,
-            textMatches=case_insensitive_re(TabBarText.RECENT_CONTENT_DESC),
+            textMatches=case_insensitive_re(TabBarText.FILTER_CONTENT),
         )
         if obj.exists(Timeout.LONG):
-            logger.debug("Recent Tab exists.")
+            logger.debug("Filter option exists.")
+            obj.click()
         else:
-            logger.debug("Recent Tab doesn't exists.")
-        return obj
+            logger.debug("Filter option doesn't exists.")
+            return False
+
+        obj = self.device.find(
+            textMatches=case_insensitive_re(TabBarText.FILTER_RECENT_CONTENT),
+        )
+        if obj.exists(Timeout.SHORT):
+            logger.debug("Filter by recent posts")
+            obj.click()
+        else:
+            logger.debug("Filter by recent posts doesn't exists")
+            return False
+        return True
 
 
-# The place view for the moment It's only a copy/paste of HashTagView
+# The place view for the moment
 # Maybe we can add the com.instagram.android:id/category_name == "Country/Region" (or other obv)
 
 
@@ -281,11 +292,16 @@ class PlacesView:
             logger.debug("First image in view doesn't exists.")
         return obj
 
-    def _getRecentTab(self):
-        return self.device.find(
+    def _navigateToRecentTab(self):
+        recent_tab = self.device.find(
             className=ClassName.TEXT_VIEW,
             textMatches=case_insensitive_re(TabBarText.RECENT_CONTENT_DESC),
         )
+        if recent_tab.exists(Timeout.MEDIUM):
+            recent_tab.click()
+            return True
+        else:
+            return False
 
     def _getInformBody(self):
         return self.device.find(
@@ -358,7 +374,9 @@ class SearchView:
                         tab_text_view = obj
                         break
             return tab_text_view
-        return None
+        else:
+            logger.debug("Tabs container doesn't exists.")
+            return None
 
     def _searchTabWithTextPlaceholder(self, tab: SearchTabs):
         tab_layout = self.device.find(
@@ -434,6 +452,8 @@ class SearchView:
         if obj is not None:
             logger.info(f"Switching to {tab.name}")
             obj.click()
+        else:
+            logger.debug("Impossible to switch to the target tab.")
 
     def _check_current_view(
         self, target: str, job: str, in_place_tab: bool = False


### PR DESCRIPTION
# Description

- This PR fix the "hashtag-posts-recent" feature. In the new UI, the bot has to click on "filter" then "Top recent posts". It was not the case on the previous version of IG. I really need this feature for my use.
- I also try to fix the "place-post-recent" feature, but I don't know how to access the ressourceId so I can't solve the bug. Therefore I only add debug logging. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- I launch the bot on my own profile with some hashtags in "hashtag-posts-recent" in my config file. The bot start interacting with some posts. 

**Test Configuration**:
* Device Model or Emulator: Samsung galaxy s22
* Android Verison: 14
* Instagram Version: 300.0.0.29.110

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my code in every way I can think of to prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules