### PR TITLE
fix #379 #407 [NEW]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Pipfile.lock
 *.log*
 *.ini
 *.db
+server-restart.py

--- a/GramAddict/core/views.py
+++ b/GramAddict/core/views.py
@@ -920,6 +920,9 @@ class PostsViewList:
             )
             obj_count = n_photos + n_videos
             media_type = MediaType.CAROUSEL
+            if obj_count == 0:
+                media_type = MediaType.REEL
+                logger.info("Activating workaround test for Bug #285 - switching to REEL media type")
         return media_type, obj_count
 
     def _like_in_post_view(

--- a/GramAddict/plugins/action_unfollow_followers.py
+++ b/GramAddict/plugins/action_unfollow_followers.py
@@ -294,6 +294,10 @@ class ActionUnfollowFollowers(Plugin):
         total_unfollows_limit_reached = False
         posts_end_detector.notify_new_page()
         prev_screen_iterated_followings = []
+        # variables to save appeared usernames
+        seen_users = set()
+        seen_user_threshold = 3 #how many people with the same usernames the bot should see again to stop
+        seen_user_count = 0
         while True:
             screen_iterated_followings = []
             logger.info("Iterate over visible followings.")
@@ -301,7 +305,8 @@ class ActionUnfollowFollowers(Plugin):
                 resourceIdMatches=self.ResourceID.USER_LIST_CONTAINER,
             )
             row_height, n_users = inspect_current_view(user_list)
-            for item in user_list:
+            for item in user_list: 
+                # inner user_list counter
                 cur_row_height = item.get_height()
                 if cur_row_height < row_height:
                     continue
@@ -316,6 +321,10 @@ class ActionUnfollowFollowers(Plugin):
 
                 username = user_name_view.get_text()
                 screen_iterated_followings.append(username)
+                # check if a username has seen previously
+                if username in seen_users:
+                    seen_user_count += 1
+                seen_users.add(username)
                 if username not in checked:
                     checked[username] = None
 
@@ -409,6 +418,13 @@ class ActionUnfollowFollowers(Plugin):
 
             if screen_iterated_followings != prev_screen_iterated_followings:
                 prev_screen_iterated_followings = screen_iterated_followings
+                # exit if reach seen threshold
+                if seen_user_count > seen_user_threshold:
+                    logger.info(
+                        "Reached the following list end, finish.",
+                        extra={"color": f"{Fore.GREEN}"},
+                    )
+                    return
                 logger.info("Need to scroll now.", extra={"color": f"{Fore.GREEN}"})
                 list_view = device.find(
                     resourceId=self.ResourceID.LIST,

--- a/server-restart.py
+++ b/server-restart.py
@@ -1,0 +1,5 @@
+import uiautomator2 as u2
+
+d = u2.connect()
+d.service("uiautomator").stop()
+d.service("uiautomator").start()

--- a/server-restart.py
+++ b/server-restart.py
@@ -1,5 +1,0 @@
-import uiautomator2 as u2
-
-d = u2.connect()
-d.service("uiautomator").stop()
-d.service("uiautomator").start()


### PR DESCRIPTION
Description
Unfollow job runs into unlimited loop due to Instagrame loop back to the first following username after the end of list https://github.com/GramAddict/bot/issues/379

Fixes # (issue)

Type of change
Please delete options that are not relevant.

[ X] Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 This change requires a documentation update
How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

[ X] Test A
 Test B
Test Configuration:

Device Model or Emulator: TCL 30Z
Android Verison: Android 14
Instagram Version: 299.0.0.34.111
Checklist:
[X] My code follows the style guidelines of this project
[X] I have performed a self-review of my own code
[X] I have commented my code, particularly in hard-to-understand areas
[X] I have made corresponding changes to the documentation
[X] My changes generate no new warnings
[X] I have tested my code in every way I can think of to prove my fix is effective or that my feature works
[X] Any dependent changes have been merged and published in downstream modules