### PR TITLE
fix: recognize command-line actions when using --config

### DIFF
--- a/GramAddict/core/bot_flow.py
+++ b/GramAddict/core/bot_flow.py
@@ -96,8 +96,20 @@ def start_bot(**kwargs):
 
     if len(configs.enabled) < 1:
         logger.error(
-            "You have to specify one of these actions: " + ", ".join(configs.actions)
+            "No actions found! You need to specify at least one action in your config file or command line."
         )
+        logger.error("Available actions: " + ", ".join(sorted(configs.actions)))
+        logger.info("")
+        logger.info("Common examples:")
+        logger.info("  - feed: 2-5                    # Like 2-5 posts from your feed")
+        logger.info("  - blogger-followers: [user1]   # Interact with user1's followers")
+        logger.info("  - unfollow: 10-20              # Unfollow 10-20 users")
+        logger.info("")
+        logger.info("To fix this:")
+        logger.info("  1. Open your config file and uncomment at least one action (remove the # symbol)")
+        logger.info("  2. Or add an action via command line, e.g.: python run.py --config config.yml --feed 5")
+        logger.info("")
+        logger.info("For more details, see: https://docs.gramaddict.org/#/configuration")
         return
     device = create_device(configs.device_id, configs.app_id)
     session_state = None

--- a/GramAddict/core/config.py
+++ b/GramAddict/core/config.py
@@ -198,15 +198,27 @@ class Config:
                     and not _is_legacy_arg(item)
                 ):
                     self.enabled.append(item)
+            # Also check sys.argv for command-line arguments that may override config
+            for item in sys.argv:
+                if item.startswith("--"):
+                    nitem = item[2:]
+                    if (
+                        nitem in self.actions
+                        and getattr(self.args, nitem.replace("-", "_")) is not None
+                        and not _is_legacy_arg(nitem)
+                        and nitem not in self.enabled
+                    ):
+                        self.enabled.append(nitem)
         else:
             for item in sys.argv:
-                nitem = item[2:]
-                if (
-                    nitem in self.actions
-                    and getattr(self.args, nitem.replace("-", "_")) is not None
-                    and not _is_legacy_arg(nitem)
-                ):
-                    self.enabled.append(nitem)
+                if item.startswith("--"):
+                    nitem = item[2:]
+                    if (
+                        nitem in self.actions
+                        and getattr(self.args, nitem.replace("-", "_")) is not None
+                        and not _is_legacy_arg(nitem)
+                    ):
+                        self.enabled.append(nitem)
 
 
 def get_time_last_save(file_path) -> str:


### PR DESCRIPTION
Fixed two issues that prevented actions from being detected:

1. Config parser now checks both config file and command-line arguments
   - Previously, when --config was used, sys.argv actions were ignored
   - Now command-line actions are added even when config file exists
   - This allows users to run: python run.py --config file.yml --feed 5

2. Improved error message when no actions are found
   - Shows available actions in alphabetical order
   - Provides clear examples of how to use actions
   - Explains both config file and command-line methods
   - Links to documentation for more details

This fixes the "No actions found!" error that occurred even when passing actions like --feed 5 on the command line.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Device Model or Emulator:
* Android Verison:
* Instagram Version:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have tested my code in every way I can think of to prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules